### PR TITLE
Refactor: SourceFormatBuilder.DeleteDocumentStructureRootAsync test enabled

### DIFF
--- a/src/DigitalLibrary.sln
+++ b/src/DigitalLibrary.sln
@@ -21,7 +21,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 	ProjectSection(SolutionItems) = preProject
 		SolutionItems\.editorconfig = SolutionItems\.editorconfig
 		..\.gitignore = ..\.gitignore
-		SolutionItems\GlobalSuppressions.cs = SolutionItems\GlobalSuppressions.cs
 		SolutionItems\stylecop.json = SolutionItems\stylecop.json
 		SolutionItems\stylecop.ruleset = SolutionItems\stylecop.ruleset
 		SolutionItems\xunit.runner.json = SolutionItems\xunit.runner.json

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureAsync_Validation_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureAsync_Validation_Should.cs
@@ -24,29 +24,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     public class AddDimensionStructureAsync_Validation_Should : TestBase
     {
         [Fact]
-        public async Task ThrowException_When_ParentIdIsZero()
-        {
-            // Arrange
-            _masterDataWebApiClientMock
-               .Setup(m => m.GetSourceFormatWithFullDimensionStructureTreeAsync(It.IsAny<SourceFormat>()))
-               .ReturnsAsync(_sourceFormat);
-            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
-                _masterDataWebApiClientMock.Object,
-                _masterDataValidatorsMock.Object,
-                _domainEntityHelperServiceMock.Object);
-            await sourceFormatBuilderService.OnUpdate(100).ConfigureAwait(false);
-
-            // Act
-            Func<Task> action = async () =>
-            {
-                await sourceFormatBuilderService.AddDimensionStructureAsync(11, null).ConfigureAwait(false);
-            };
-
-            // Assert
-            action.Should().ThrowExactly<GuardException>();
-        }
-
-        [Fact]
         public async Task ThrowException_When_DimensionStructureParamIsNull()
         {
             // Arrange
@@ -64,6 +41,29 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
             {
                 await sourceFormatBuilderService.AddDimensionStructureAsync(0, dimensionStructure)
                    .ConfigureAwait(false);
+            };
+
+            // Assert
+            action.Should().ThrowExactly<GuardException>();
+        }
+
+        [Fact]
+        public async Task ThrowException_When_ParentIdIsZero()
+        {
+            // Arrange
+            _masterDataWebApiClientMock
+               .Setup(m => m.GetSourceFormatWithFullDimensionStructureTreeAsync(It.IsAny<SourceFormat>()))
+               .ReturnsAsync(_sourceFormat);
+            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
+                _masterDataWebApiClientMock.Object,
+                _masterDataValidatorsMock.Object,
+                _domainEntityHelperServiceMock.Object);
+            await sourceFormatBuilderService.OnUpdate(100).ConfigureAwait(false);
+
+            // Act
+            Func<Task> action = async () =>
+            {
+                await sourceFormatBuilderService.AddDimensionStructureAsync(11, null).ConfigureAwait(false);
             };
 
             // Assert

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureAsync_Validation_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureAsync_Validation_Should.cs
@@ -17,6 +17,10 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     using Xunit;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "CA1707")]
+    [SuppressMessage("ReSharper", "SA1600")]
+    [SuppressMessage("ReSharper", "SA1404")]
     public class AddDimensionStructureAsync_Validation_Should : TestBase
     {
         [Fact]

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureRootAsync_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureRootAsync_Should.cs
@@ -22,31 +22,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     public class AddDimensionStructureRootAsync_Should : TestBase
     {
         [Fact]
-        public async Task ThrowException_SourceFormatHasRootDimensionStructure()
-        {
-            // Arrange
-            _masterDataWebApiClientMock
-               .Setup(m => m.GetSourceFormatWithFullDimensionStructureTreeAsync(It.IsAny<SourceFormat>()))
-               .ReturnsAsync(_sourceFormat);
-            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
-                _masterDataWebApiClientMock.Object,
-                _masterDataValidatorsMock.Object,
-                _domainEntityHelperServiceMock.Object);
-            DimensionStructure dimensionStructure = new DimensionStructure();
-
-            // Act
-            Func<Task> action = async () =>
-            {
-                await sourceFormatBuilderService.OnUpdate(100).ConfigureAwait(false);
-                await sourceFormatBuilderService.AddDimensionStructureRootAsync(
-                    dimensionStructure).ConfigureAwait(false);
-            };
-
-            // Assert
-            action.Should().ThrowExactly<SourceFormatBuilderServiceException>();
-        }
-
-        [Fact]
         public async Task AddDimensionStructureToRoot()
         {
             // Arrange
@@ -71,6 +46,31 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
             // Assert
             sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Should().NotBeNull();
             sourceFormatBuilderService.SourceFormat.RootDimensionStructureId.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task ThrowException_SourceFormatHasRootDimensionStructure()
+        {
+            // Arrange
+            _masterDataWebApiClientMock
+               .Setup(m => m.GetSourceFormatWithFullDimensionStructureTreeAsync(It.IsAny<SourceFormat>()))
+               .ReturnsAsync(_sourceFormat);
+            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
+                _masterDataWebApiClientMock.Object,
+                _masterDataValidatorsMock.Object,
+                _domainEntityHelperServiceMock.Object);
+            DimensionStructure dimensionStructure = new DimensionStructure();
+
+            // Act
+            Func<Task> action = async () =>
+            {
+                await sourceFormatBuilderService.OnUpdate(100).ConfigureAwait(false);
+                await sourceFormatBuilderService.AddDimensionStructureRootAsync(
+                    dimensionStructure).ConfigureAwait(false);
+            };
+
+            // Assert
+            action.Should().ThrowExactly<SourceFormatBuilderServiceException>();
         }
     }
 }

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureRootAsync_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureRootAsync_Should.cs
@@ -16,6 +16,9 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
 
     [ExcludeFromCodeCoverage]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "CA1707")]
+    [SuppressMessage("ReSharper", "SA1600")]
+    [SuppressMessage("ReSharper", "SA1404")]
     public class AddDimensionStructureRootAsync_Should : TestBase
     {
         [Fact]

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureRootAsync_Validation_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/AddDimensionStructureRootAsync_Validation_Should.cs
@@ -17,6 +17,10 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     using Xunit;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "CA1707")]
+    [SuppressMessage("ReSharper", "SA1600")]
+    [SuppressMessage("ReSharper", "SA1404")]
     public class AddDimensionStructureRootAsync_Validation_Should : TestBase
     {
         [Fact]

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/AddOrUpdateDocumentStructureToTreeAsync_Add_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/AddOrUpdateDocumentStructureToTreeAsync_Add_Should.cs
@@ -6,19 +6,10 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
 
     public class AddOrUpdateDocumentStructureToTreeAsync_Add_Should : TestBase
     {
-        [Fact]
-        public async Task AddItem_ToRootDimension()
-        {
-        }
-
-        [Fact]
-        public async Task AddItemTo_FirstLevel_EmptyLengthList()
-        {
-        }
-
         /// <summary>
-        /// Until this: https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
-        /// is not solved this part of the testing is suspended
+        ///     Until this:
+        ///     https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
+        ///     is not solved this part of the testing is suspended
         /// </summary>
         /// <returns></returns>
         public async Task AddItemTo_FirstLevel_ListHasMultipleItems()
@@ -26,8 +17,9 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
         }
 
         /// <summary>
-        /// Until this: https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
-        /// is not solved this part of the testing is suspended
+        ///     Until this:
+        ///     https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
+        ///     is not solved this part of the testing is suspended
         /// </summary>
         /// <returns></returns>
         public async Task AddItemTo_SecondLevel_EmptyList()
@@ -35,8 +27,9 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
         }
 
         /// <summary>
-        /// Until this: https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
-        /// is not solved this part of the testing is suspended
+        ///     Until this:
+        ///     https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
+        ///     is not solved this part of the testing is suspended
         /// </summary>
         /// <returns></returns>
         public async Task AddItemTo_SecondLevel_LastHasMultipleItems()
@@ -44,11 +37,22 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
         }
 
         /// <summary>
-        /// Until this: https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
-        /// is not solved this part of the testing is suspended
+        ///     Until this:
+        ///     https://stackoverflow.com/questions/60441646/how-to-setup-moq-for-the-same-method-where-return-value-depends-on-input
+        ///     is not solved this part of the testing is suspended
         /// </summary>
         /// <returns></returns>
         public async Task AddItemTo_WhenAnItemIsAdded()
+        {
+        }
+
+        [Fact]
+        public async Task AddItem_ToRootDimension()
+        {
+        }
+
+        [Fact]
+        public async Task AddItemTo_FirstLevel_EmptyLengthList()
         {
         }
     }

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/AddOrUpdateDocumentStructureToTreeAsync_Update_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/AddOrUpdateDocumentStructureToTreeAsync_Update_Should.cs
@@ -7,11 +7,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     public class AddOrUpdateDocumentStructureToTreeAsync_Update_Should : TestBase
     {
         [Fact]
-        public async Task UpdateItem_RootDimension()
-        {
-        }
-
-        [Fact]
         public async Task ReturnSilently_IfthereIsNoItemToUpdate()
         {
         }
@@ -28,6 +23,11 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
 
         [Fact]
         public async Task UpdateItem_AtThirdLevel()
+        {
+        }
+
+        [Fact]
+        public async Task UpdateItem_RootDimension()
         {
         }
     }

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/DeleteDimensionStructureRootAsync_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/DeleteDimensionStructureRootAsync_Should.cs
@@ -14,6 +14,10 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     using Xunit;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "CA1707")]
+    [SuppressMessage("ReSharper", "SA1600")]
+    [SuppressMessage("ReSharper", "SA1404")]
     public class DeleteDimensionStructureRootAsync_Should : TestBase
     {
         [Fact]

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/DeleteDimensionStructureRootAsync_Validation_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/DeleteDimensionStructureRootAsync_Validation_Should.cs
@@ -17,6 +17,10 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     using Xunit;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [SuppressMessage("ReSharper", "CA1707")]
+    [SuppressMessage("ReSharper", "SA1600")]
+    [SuppressMessage("ReSharper", "SA1404")]
     public class DeleteDimensionStructureRootAsync_Validation_Should : TestBase
     {
         [Fact]
@@ -48,7 +52,7 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
             action.Should().ThrowExactly<GuardException>();
         }
 
-        [Fact(Skip = "tmp")]
+        [Fact]
         public async Task ThrowException_WhenSourceFormatIsNull()
         {
             // Arrange
@@ -56,6 +60,7 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
                 _masterDataWebApiClientMock.Object,
                 _masterDataValidatorsMock.Object,
                 _domainEntityHelperServiceMock.Object);
+            sourceFormatBuilderService.SourceFormat = null;
             DimensionStructure dimensionStructure = new DimensionStructure
             {
                 Name = "Something root",

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/RemoveItemFromTreeAsync_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/RemoveItemFromTreeAsync_Should.cs
@@ -22,27 +22,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     public class RemoveItemFromTreeAsync_Should : TestBase
     {
         [Fact]
-        public async Task ThrowException_WhenNoDimensionToBeDeletedSetup()
-        {
-            // Arrange
-            ISourceFormatBuilderService builderService = new SourceFormatBuilderService(
-                _masterDataWebApiClientMock.Object,
-                _masterDataValidatorsMock.Object,
-                _domainEntityHelperServiceMock.Object);
-            builderService.DimensionStructureToBeDeletedFromTree = null;
-
-            // Act
-            Func<Task> action = async () =>
-            {
-                await builderService.DeleteDocumentStructureFromTreeAsync()
-                   .ConfigureAwait(false);
-            };
-
-            // Assert
-            action.Should().ThrowExactly<GuardException>();
-        }
-
-        [Fact]
         public async Task Remove_RootDimensionStructure()
         {
             // Arrange
@@ -54,61 +33,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
                 Desc = "Desc",
                 ChildDimensionStructures = new List<DimensionStructure>(),
             };
-        }
-
-        [Fact(Skip = "tmp")]
-        public async Task RemoveItem_WhenOnlyASingleItemIsOnTheFirstLevel()
-        {
-            // Arrange
-            DimensionStructure firstLevelFirst = new DimensionStructure
-            {
-                Id = 101,
-                Name = "one oh one",
-                Desc = "one oh one",
-            };
-            List<DimensionStructure> childDimensionStructures = new List<DimensionStructure>
-            {
-                firstLevelFirst,
-            };
-            DimensionStructure rootDimensionStructure = new DimensionStructure
-            {
-                Id = 100,
-                Name = "root",
-                Desc = "root",
-                ChildDimensionStructures = childDimensionStructures,
-            };
-            SourceFormat testData = new SourceFormat
-            {
-                Id = 100,
-                Name = "test",
-                Desc = "test desc",
-                RootDimensionStructureId = 100,
-                RootDimensionStructure = rootDimensionStructure,
-            };
-
-            _masterDataWebApiClientMock
-               .Setup(m => m.GetSourceFormatWithFullDimensionStructureTreeAsync(It.IsAny<SourceFormat>()))
-               .ReturnsAsync(testData);
-
-            ISourceFormatBuilderService builderService = new SourceFormatBuilderService(
-                _masterDataWebApiClientMock.Object,
-                _masterDataValidatorsMock.Object,
-                _domainEntityHelperServiceMock.Object);
-            await builderService.OnUpdate(100).ConfigureAwait(false);
-            builderService.DimensionStructureToBeDeletedFromTree = firstLevelFirst;
-
-            // Act
-            await builderService.DeleteDocumentStructureFromTreeAsync().ConfigureAwait(false);
-
-            // Assert
-            builderService.SourceFormat.Should().NotBeNull();
-            builderService.SourceFormat.Id.Should().Be(testData.Id);
-            builderService.SourceFormat.Name.Should().Be(testData.Name);
-            builderService.SourceFormat.Desc.Should().Be(testData.Desc);
-
-            builderService.SourceFormat.RootDimensionStructure.Id.Should().Be(rootDimensionStructure.Id);
-
-            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures.Count.Should().Be(0);
         }
 
         [Fact(Skip = "tmp")]
@@ -176,49 +100,18 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
         }
 
         [Fact(Skip = "tmp")]
-        public async Task RemoveItemWithItsChildren_WhenMultipleItemsOnTheFirstLevel_AndOneOfThemHasChild()
+        public async Task RemoveItem_WhenOnlyASingleItemIsOnTheFirstLevel()
         {
             // Arrange
-            DimensionStructure secondLevelFirst = new DimensionStructure
-            {
-                Id = 201,
-                Name = "two oh one",
-                Desc = "two oh one",
-            };
-            DimensionStructure secondLevelSecond = new DimensionStructure
-            {
-                Id = 202,
-                Name = "two oh two",
-                Desc = "two oh two",
-            };
-            DimensionStructure firstLevelThird = new DimensionStructure
-            {
-                Id = 103,
-                Name = "one of three",
-                Desc = "one oh three",
-                ChildDimensionStructures = new List<DimensionStructure>
-                {
-                    secondLevelFirst,
-                    secondLevelSecond
-                },
-            };
             DimensionStructure firstLevelFirst = new DimensionStructure
             {
                 Id = 101,
                 Name = "one oh one",
                 Desc = "one oh one",
             };
-            DimensionStructure firstLevelSecond = new DimensionStructure
-            {
-                Id = 102,
-                Name = "two oh two",
-                Desc = "two oh two",
-            };
             List<DimensionStructure> childDimensionStructures = new List<DimensionStructure>
             {
                 firstLevelFirst,
-                firstLevelSecond,
-                firstLevelThird,
             };
             DimensionStructure rootDimensionStructure = new DimensionStructure
             {
@@ -245,7 +138,7 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
                 _masterDataValidatorsMock.Object,
                 _domainEntityHelperServiceMock.Object);
             await builderService.OnUpdate(100).ConfigureAwait(false);
-            builderService.DimensionStructureToBeDeletedFromTree = firstLevelThird;
+            builderService.DimensionStructureToBeDeletedFromTree = firstLevelFirst;
 
             // Act
             await builderService.DeleteDocumentStructureFromTreeAsync().ConfigureAwait(false);
@@ -258,11 +151,7 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
 
             builderService.SourceFormat.RootDimensionStructure.Id.Should().Be(rootDimensionStructure.Id);
 
-            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures.Count.Should().Be(2);
-            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures
-               .Where(p => p.Id == firstLevelFirst.Id).ToList().Count.Should().Be(1);
-            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures
-               .Where(p => p.Id == firstLevelSecond.Id).ToList().Count.Should().Be(1);
+            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures.Count.Should().Be(0);
         }
 
         [Fact(Skip = "tmp")]
@@ -393,6 +282,117 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
                .FirstOrDefault(p => p.Id == firstLevelThird.Id)
                .ChildDimensionStructures
                .Where(q => q.Id == secondLevelSecond.Id).ToList().Count.Should().Be(1);
+        }
+
+        [Fact(Skip = "tmp")]
+        public async Task RemoveItemWithItsChildren_WhenMultipleItemsOnTheFirstLevel_AndOneOfThemHasChild()
+        {
+            // Arrange
+            DimensionStructure secondLevelFirst = new DimensionStructure
+            {
+                Id = 201,
+                Name = "two oh one",
+                Desc = "two oh one",
+            };
+            DimensionStructure secondLevelSecond = new DimensionStructure
+            {
+                Id = 202,
+                Name = "two oh two",
+                Desc = "two oh two",
+            };
+            DimensionStructure firstLevelThird = new DimensionStructure
+            {
+                Id = 103,
+                Name = "one of three",
+                Desc = "one oh three",
+                ChildDimensionStructures = new List<DimensionStructure>
+                {
+                    secondLevelFirst,
+                    secondLevelSecond
+                },
+            };
+            DimensionStructure firstLevelFirst = new DimensionStructure
+            {
+                Id = 101,
+                Name = "one oh one",
+                Desc = "one oh one",
+            };
+            DimensionStructure firstLevelSecond = new DimensionStructure
+            {
+                Id = 102,
+                Name = "two oh two",
+                Desc = "two oh two",
+            };
+            List<DimensionStructure> childDimensionStructures = new List<DimensionStructure>
+            {
+                firstLevelFirst,
+                firstLevelSecond,
+                firstLevelThird,
+            };
+            DimensionStructure rootDimensionStructure = new DimensionStructure
+            {
+                Id = 100,
+                Name = "root",
+                Desc = "root",
+                ChildDimensionStructures = childDimensionStructures,
+            };
+            SourceFormat testData = new SourceFormat
+            {
+                Id = 100,
+                Name = "test",
+                Desc = "test desc",
+                RootDimensionStructureId = 100,
+                RootDimensionStructure = rootDimensionStructure,
+            };
+
+            _masterDataWebApiClientMock
+               .Setup(m => m.GetSourceFormatWithFullDimensionStructureTreeAsync(It.IsAny<SourceFormat>()))
+               .ReturnsAsync(testData);
+
+            ISourceFormatBuilderService builderService = new SourceFormatBuilderService(
+                _masterDataWebApiClientMock.Object,
+                _masterDataValidatorsMock.Object,
+                _domainEntityHelperServiceMock.Object);
+            await builderService.OnUpdate(100).ConfigureAwait(false);
+            builderService.DimensionStructureToBeDeletedFromTree = firstLevelThird;
+
+            // Act
+            await builderService.DeleteDocumentStructureFromTreeAsync().ConfigureAwait(false);
+
+            // Assert
+            builderService.SourceFormat.Should().NotBeNull();
+            builderService.SourceFormat.Id.Should().Be(testData.Id);
+            builderService.SourceFormat.Name.Should().Be(testData.Name);
+            builderService.SourceFormat.Desc.Should().Be(testData.Desc);
+
+            builderService.SourceFormat.RootDimensionStructure.Id.Should().Be(rootDimensionStructure.Id);
+
+            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures.Count.Should().Be(2);
+            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures
+               .Where(p => p.Id == firstLevelFirst.Id).ToList().Count.Should().Be(1);
+            builderService.SourceFormat.RootDimensionStructure.ChildDimensionStructures
+               .Where(p => p.Id == firstLevelSecond.Id).ToList().Count.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task ThrowException_WhenNoDimensionToBeDeletedSetup()
+        {
+            // Arrange
+            ISourceFormatBuilderService builderService = new SourceFormatBuilderService(
+                _masterDataWebApiClientMock.Object,
+                _masterDataValidatorsMock.Object,
+                _domainEntityHelperServiceMock.Object);
+            builderService.DimensionStructureToBeDeletedFromTree = null;
+
+            // Act
+            Func<Task> action = async () =>
+            {
+                await builderService.DeleteDocumentStructureFromTreeAsync()
+                   .ConfigureAwait(false);
+            };
+
+            // Assert
+            action.Should().ThrowExactly<GuardException>();
         }
     }
 }

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/ReplaceDimensionStructureInTheTreeAsync_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/ReplaceDimensionStructureInTheTreeAsync_Should.cs
@@ -9,16 +9,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     public class ReplaceDimensionStructureInTheTreeAsync_Should : TestBase
     {
         [Fact]
-        public async Task ReplaceRootDimension()
-        {
-        }
-
-        [Fact]
-        public async Task ThrowException_WhenDimensionStructureIs_NotInTheTree()
-        {
-        }
-
-        [Fact]
         public async Task ReplaceDimensionStructure_AtFirstLevel()
         {
         }
@@ -34,7 +24,17 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
         }
 
         [Fact]
+        public async Task ReplaceRootDimension()
+        {
+        }
+
+        [Fact]
         public async Task ReplaceRootDimensionStructure_AndIncludeAllChildDimensionsOfTheAddedOne()
+        {
+        }
+
+        [Fact]
+        public async Task ThrowException_WhenDimensionStructureIs_NotInTheTree()
         {
         }
     }

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/SaveNewRootDimensionStructureHandlerAsync_Should.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/SaveNewRootDimensionStructureHandlerAsync_Should.cs
@@ -4,13 +4,13 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
 
-    using DigitalLibrary.MasterData.DomainModel;
-    using DigitalLibrary.MasterData.Validators.TestData;
-    using DigitalLibrary.Ui.WebUi.Components.SourceFormatBuilder;
-
     using FluentAssertions;
 
     using FluentValidation;
+
+    using MasterData.DomainModel;
+
+    using WebUi.Components.SourceFormatBuilder;
 
     using Xunit;
 
@@ -19,28 +19,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     // ReSharper disable once CA1707
     public class SaveNewRootDimensionStructureHandlerAsync_Should : TestBase
     {
-        [Fact]
-        public async Task ThrowException_WhenInputIsNull()
-        {
-            // Arrange
-            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
-                _masterDataWebApiClientMock.Object,
-                _masterDataValidatorsMock.Object,
-                _domainEntityHelperServiceMock.Object);
-
-            // Act
-            Func<Task> action = async () =>
-            {
-                await sourceFormatBuilderService.SaveNewRootDimensionStructureHandlerAsync(
-                        null)
-                   .ConfigureAwait(false);
-            };
-
-            // Assert
-            action.Should().ThrowExactly<SourceFormatBuilderServiceException>();
-        }
-
-
         [Theory(Skip = "tmp")]
         [InlineData(1, "name", "desc", 1)]
         [InlineData(0, "", "desc", 1)]
@@ -134,38 +112,6 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
         }
 
         [Fact(Skip = "tmp")]
-        public async Task AddDimensionStructureWithoutDimension_AsRootDimensionStructure()
-        {
-            // Arrange
-            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
-                _masterDataWebApiClientMock.Object,
-                _masterDataValidatorsMock.Object,
-                _domainEntityHelperServiceMock.Object);
-
-            DimensionStructure dimensionStructure = new DimensionStructure
-            {
-                Id = 0,
-                Name = "name",
-                Desc = "desc",
-                IsActive = 1,
-            };
-
-            // Act
-            await sourceFormatBuilderService.SaveNewRootDimensionStructureHandlerAsync(dimensionStructure)
-               .ConfigureAwait(false);
-
-            // Assert
-            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Id
-               .Should().Be(dimensionStructure.Id);
-            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Name
-               .Should().Be(dimensionStructure.Name);
-            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Desc
-               .Should().Be(dimensionStructure.Desc);
-            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.IsActive
-               .Should().Be(dimensionStructure.IsActive);
-        }
-
-        [Fact(Skip = "tmp")]
         public async Task AddDimensionStructureWithDimension_AsRootDimensionStructure()
         {
             // Arrange
@@ -207,6 +153,59 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
                .Should().Be(dimensionStructure.IsActive);
             sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Id
                .Should().Be(dimensionStructure.Id);
+        }
+
+        [Fact(Skip = "tmp")]
+        public async Task AddDimensionStructureWithoutDimension_AsRootDimensionStructure()
+        {
+            // Arrange
+            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
+                _masterDataWebApiClientMock.Object,
+                _masterDataValidatorsMock.Object,
+                _domainEntityHelperServiceMock.Object);
+
+            DimensionStructure dimensionStructure = new DimensionStructure
+            {
+                Id = 0,
+                Name = "name",
+                Desc = "desc",
+                IsActive = 1,
+            };
+
+            // Act
+            await sourceFormatBuilderService.SaveNewRootDimensionStructureHandlerAsync(dimensionStructure)
+               .ConfigureAwait(false);
+
+            // Assert
+            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Id
+               .Should().Be(dimensionStructure.Id);
+            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Name
+               .Should().Be(dimensionStructure.Name);
+            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.Desc
+               .Should().Be(dimensionStructure.Desc);
+            sourceFormatBuilderService.SourceFormat.RootDimensionStructure.IsActive
+               .Should().Be(dimensionStructure.IsActive);
+        }
+
+        [Fact]
+        public async Task ThrowException_WhenInputIsNull()
+        {
+            // Arrange
+            ISourceFormatBuilderService sourceFormatBuilderService = new SourceFormatBuilderService(
+                _masterDataWebApiClientMock.Object,
+                _masterDataValidatorsMock.Object,
+                _domainEntityHelperServiceMock.Object);
+
+            // Act
+            Func<Task> action = async () =>
+            {
+                await sourceFormatBuilderService.SaveNewRootDimensionStructureHandlerAsync(
+                        null)
+                   .ConfigureAwait(false);
+            };
+
+            // Assert
+            action.Should().ThrowExactly<SourceFormatBuilderServiceException>();
         }
     }
 }

--- a/src/Host/WebUI.Test/SourceFormatBuilderService/TestBase.cs
+++ b/src/Host/WebUI.Test/SourceFormatBuilderService/TestBase.cs
@@ -2,9 +2,9 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
 {
     using System.Diagnostics.CodeAnalysis;
 
-    using DigitalLibrary.MasterData.DomainModel;
-    using DigitalLibrary.MasterData.Validators;
-    using DigitalLibrary.MasterData.WebApi.Client;
+    using MasterData.DomainModel;
+    using MasterData.Validators;
+    using MasterData.WebApi.Client;
 
     using Moq;
 
@@ -13,20 +13,12 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
     [ExcludeFromCodeCoverage]
     public class TestBase
     {
-        protected Mock<IMasterDataHttpClient> _masterDataWebApiClientMock = new Mock<IMasterDataHttpClient>();
-
-        protected Mock<IMasterDataValidators> _masterDataValidatorsMock = new Mock<IMasterDataValidators>();
-
         protected Mock<IDomainEntityHelperService> _domainEntityHelperServiceMock =
             new Mock<IDomainEntityHelperService>();
 
-        protected SourceFormat _sourceFormatWithoutRootDimensionStructure = new SourceFormat
-        {
-            Id = 100,
-            Name = "Test Source Format",
-            Desc = "Test Source Format Description",
-            IsActive = 1,
-        };
+        protected Mock<IMasterDataValidators> _masterDataValidatorsMock = new Mock<IMasterDataValidators>();
+
+        protected Mock<IMasterDataHttpClient> _masterDataWebApiClientMock = new Mock<IMasterDataHttpClient>();
 
         protected SourceFormat _sourceFormat = new SourceFormat
         {
@@ -36,6 +28,14 @@ namespace DigitalLibrary.Ui.WebUI.Test.SourceFormatBuilderService
             IsActive = 1,
             RootDimensionStructure = new DimensionStructure(),
             RootDimensionStructureId = 100,
+        };
+
+        protected SourceFormat _sourceFormatWithoutRootDimensionStructure = new SourceFormat
+        {
+            Id = 100,
+            Name = "Test Source Format",
+            Desc = "Test Source Format Description",
+            IsActive = 1,
         };
 
         protected MasterDataValidators GetMasterDataValidators()

--- a/src/SolutionItems/GlobalSuppressions.cs
+++ b/src/SolutionItems/GlobalSuppressions.cs
@@ -1,0 +1,1 @@
+[assembly:System.Diagnostics.CodeAnalysis.SurpressMessage("Style", "SA1404")]


### PR DESCRIPTION
# Description

When #25 was merged I had to disable a few tests in order to get a green build.
This PR enables one of those tests.

## Motivation & context
The SourceFormatBuilder functionality has to be covered by tests.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **Refactor**: A change which enhances the code or other aspects of the overall quality
- [ ] **New feature**: A change that adds functionality.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feature: add a border radius to button
    refactor: rework of some component
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->
